### PR TITLE
Adding timeout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,3 +352,16 @@ var FB = require('FB');
 FB.setAccessToken('access_token');
 var accessToken = FB.getAccessToken();
 ```
+
+### setMaxWait
+*This is a non-standard api and does not exist in the official client side FB JS SDK.*
+
+Api calls will timeout if you do not get a response within the set waiting time period. Timeouts will return errors to the api callback in the format:
+```js
+{error:'ETIMEDOUT'}
+```
+
+```js
+var FB = require('FB');
+FB.setMaxWait(5000); //defined in milliseconds
+```

--- a/README.md
+++ b/README.md
@@ -353,13 +353,14 @@ FB.setAccessToken('access_token');
 var accessToken = FB.getAccessToken();
 ```
 
+## Extra Options
+
+__The options defined here are not apart of the standard api, but should be useful for server side logic.__
+
 ### setMaxWait
 *This is a non-standard api and does not exist in the official client side FB JS SDK.*
 
-Api calls will timeout if you do not get a response within the set waiting time period. Timeouts will return errors to the api callback in the format:
-```js
-{error:'ETIMEDOUT'}
-```
+Api calls will timeout if you do not get a response within the set waiting time period. Timeouts will return errors to the api callback in the format `{error:'ETIMEDOUT'}`
 
 ```js
 var FB = require('FB');

--- a/fb.js
+++ b/fb.js
@@ -11,6 +11,7 @@
             , setAccessToken
             , getAccessToken
             , log
+            , timeout
             , METHODS = ['get', 'post', 'delete', 'put']
             , readOnlyCalls = {
                   'admin.getallocation': true
@@ -206,7 +207,8 @@
             var   uri
                 , body
                 , key
-                , value;
+                , value
+                , options;
 
             if(!params.access_token && accessToken) {
                 params.access_token = accessToken;
@@ -254,13 +256,20 @@
                 uri = uri.substring(0, uri.length -1);
             };
 
-            request({
-                  method: method
-                , uri: uri
-                , body: body
+            options = {
+                method: method
+              , uri: uri
+              , body: body
+            };
+            if(timeout) {
+                options['timeout'] = timeout;
             }
+            request(options
             ,function(error, response, body) {
                 if(error !== null) {
+                    if(error.hasOwnProperty('code')) {
+                        return cb({error: error.code});
+                    }
                     console.log(error);
                     return;
                 }
@@ -282,10 +291,15 @@
             accessToken = access_token;
         };
         
+        setMaxWait = function(t) {
+            timeout = t;
+        };
+        
         return {
               api: api
             , getAccessToken: getAccessToken
             , setAccessToken: setAccessToken // this method does not exist in fb js sdk
+            , setMaxWait: setMaxWait         // this method does not exist in fb js sdk
         };
 
     })();
@@ -293,3 +307,4 @@
     module.exports = FB;
 
 })();
+


### PR DESCRIPTION
I need to make millions of api calls per day, and needed to throttle the amount of open calls I had at any one time. When I have an api call that takes longer than 60 seconds to respond I know it has timed out, and needs to be retried. So I added the setMaxWait option. This sets the timeout option on the request.

Then to make sure the code can see that a timeout happened, I send any error that had an error code back to the callback so I can correctly handle the timeout errors (or any other error code).

I didn't call the method "setTimeout" because it breaks the global setTimeout.
