### PR TITLE
Return errors to callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,14 +353,13 @@ FB.setAccessToken('access_token');
 var accessToken = FB.getAccessToken();
 ```
 
-## Extra Options
-
-__The options defined here are not apart of the standard api, but should be useful for server side logic.__
-
 ### setMaxWait
 *This is a non-standard api and does not exist in the official client side FB JS SDK.*
 
-Api calls will timeout if you do not get a response within the set waiting time period. Timeouts will return errors to the api callback in the format `{error:'ETIMEDOUT'}`
+Api calls will timeout if you do not get a response within the set waiting time period. Timeouts will return errors to the api callback in the format:
+```js
+{error:'ETIMEDOUT'}
+```
 
 ```js
 var FB = require('FB');

--- a/README.md
+++ b/README.md
@@ -365,12 +365,18 @@ Some examples of various error codes you can check for:
 
 ```js
 var FB = require('FB');
+FB.options({timeout: 1});
 FB.api('/me', function (res) {
-    if(r && r.error && r.error.code === 'ETIMEDOUT') {
-        console.log('request timeout');
+    if(res && res.error)
+        if(res.error.code === 'ETIMEDOUT') {
+            console.log('request timeout');
+        }
+        else {
+            console.log('error', res.error);
+        }
     }
     else {
-        console.log(r.error);
+        console.log(res);
     }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Some examples of various error codes you can check for:
 
 ```js
 var FB = require('FB');
+FB.setAccessToken('access_token');
 FB.api('/me', function (res) {
     if(res && res.error) {
         if(res.error.code === 'ETIMEDOUT') {

--- a/README.md
+++ b/README.md
@@ -352,16 +352,3 @@ var FB = require('FB');
 FB.setAccessToken('access_token');
 var accessToken = FB.getAccessToken();
 ```
-
-### setMaxWait
-*This is a non-standard api and does not exist in the official client side FB JS SDK.*
-
-Api calls will timeout if you do not get a response within the set waiting time period. Timeouts will return errors to the api callback in the format:
-```js
-{error:'ETIMEDOUT'}
-```
-
-```js
-var FB = require('FB');
-FB.setMaxWait(5000); //defined in milliseconds
-```

--- a/README.md
+++ b/README.md
@@ -365,9 +365,8 @@ Some examples of various error codes you can check for:
 
 ```js
 var FB = require('FB');
-FB.options({timeout: 1});
 FB.api('/me', function (res) {
-    if(res && res.error)
+    if(res && res.error) {
         if(res.error.code === 'ETIMEDOUT') {
             console.log('request timeout');
         }

--- a/README.md
+++ b/README.md
@@ -352,3 +352,16 @@ var FB = require('FB');
 FB.setAccessToken('access_token');
 var accessToken = FB.getAccessToken();
 ```
+
+### setMaxWait
+*This is a non-standard api and does not exist in the official client side FB JS SDK.*
+
+Api calls will timeout if you do not get a response within the set waiting time period. Timeouts will return errors to the api callback in the format:
+```js
+{error:'ETIMEDOUT'}
+```
+
+```js
+var FB = require('FB');
+FB.setMaxWait(5000); //defined in milliseconds
+```

--- a/README.md
+++ b/README.md
@@ -353,13 +353,14 @@ FB.setAccessToken('access_token');
 var accessToken = FB.getAccessToken();
 ```
 
+## Extra Options
+
+__The options defined here are not apart of the standard api, but should be useful for server side logic.__
+
 ### setMaxWait
 *This is a non-standard api and does not exist in the official client side FB JS SDK.*
 
-Api calls will timeout if you do not get a response within the set waiting time period. Timeouts will return errors to the api callback in the format:
-```js
-{error:'ETIMEDOUT'}
-```
+Api calls will timeout if you do not get a response within the set waiting time period. Timeouts will return errors to the api callback in the format `{error:'ETIMEDOUT'}`
 
 ```js
 var FB = require('FB');

--- a/README.md
+++ b/README.md
@@ -352,3 +352,25 @@ var FB = require('FB');
 FB.setAccessToken('access_token');
 var accessToken = FB.getAccessToken();
 ```
+
+## Error handling
+
+*Note facebook is not consistent with their error format, and different systems can fail causing different error formats*
+
+Some examples of various error codes you can check for:
+* `'ECONNRESET'` - connection reset by peer
+* `'ETIMEDOUT'` - connection timed out
+* `'ESOCKETTIMEDOUT'` - socket timed out
+
+
+```js
+var FB = require('FB');
+FB.api('/me', function (res) {
+    if(r && r.error && r.error.code === 'ETIMEDOUT') {
+        console.log('request timeout');
+    }
+    else {
+        console.log(r.error);
+    }
+});
+```

--- a/fb.js
+++ b/fb.js
@@ -261,7 +261,7 @@
             }
             ,function(error, response, body) {
                 if(error !== null) {
-                    if(error.hasOwnProperty('error')) {
+                    if(error === Object(error) && error.hasOwnProperty('error')) {
                         return cb(error);
                     }
                     return cb({error:error});

--- a/fb.js
+++ b/fb.js
@@ -11,7 +11,6 @@
             , setAccessToken
             , getAccessToken
             , log
-            , timeout
             , METHODS = ['get', 'post', 'delete', 'put']
             , readOnlyCalls = {
                   'admin.getallocation': true
@@ -207,8 +206,7 @@
             var   uri
                 , body
                 , key
-                , value
-                , options;
+                , value;
 
             if(!params.access_token && accessToken) {
                 params.access_token = accessToken;
@@ -256,20 +254,13 @@
                 uri = uri.substring(0, uri.length -1);
             };
 
-            options = {
-                method: method
-              , uri: uri
-              , body: body
-            };
-            if(timeout) {
-                options['timeout'] = timeout;
+            request({
+                  method: method
+                , uri: uri
+                , body: body
             }
-            request(options
             ,function(error, response, body) {
                 if(error !== null) {
-                    if(error.hasOwnProperty('code')) {
-                        return cb({error: error.code});
-                    }
                     console.log(error);
                     return;
                 }
@@ -291,15 +282,10 @@
             accessToken = access_token;
         };
         
-        setMaxWait = function(t) {
-            timeout = t;
-        };
-        
         return {
               api: api
             , getAccessToken: getAccessToken
             , setAccessToken: setAccessToken // this method does not exist in fb js sdk
-            , setMaxWait: setMaxWait         // this method does not exist in fb js sdk
         };
 
     })();
@@ -307,4 +293,3 @@
     module.exports = FB;
 
 })();
-

--- a/fb.js
+++ b/fb.js
@@ -11,6 +11,7 @@
             , setAccessToken
             , getAccessToken
             , log
+            , timeout
             , METHODS = ['get', 'post', 'delete', 'put']
             , readOnlyCalls = {
                   'admin.getallocation': true
@@ -206,7 +207,8 @@
             var   uri
                 , body
                 , key
-                , value;
+                , value
+                , options;
 
             if(!params.access_token && accessToken) {
                 params.access_token = accessToken;
@@ -254,13 +256,20 @@
                 uri = uri.substring(0, uri.length -1);
             };
 
-            request({
-                  method: method
-                , uri: uri
-                , body: body
+            options = {
+                method: method
+              , uri: uri
+              , body: body
+            };
+            if(timeout) {
+                options['timeout'] = timeout;
             }
+            request(options
             ,function(error, response, body) {
                 if(error !== null) {
+                    if(error.hasOwnProperty('code')) {
+                        return cb({error: error.code});
+                    }
                     console.log(error);
                     return;
                 }
@@ -282,10 +291,15 @@
             accessToken = access_token;
         };
         
+        setMaxWait = function(t) {
+            timeout = t;
+        };
+        
         return {
               api: api
             , getAccessToken: getAccessToken
             , setAccessToken: setAccessToken // this method does not exist in fb js sdk
+            , setMaxWait: setMaxWait         // this method does not exist in fb js sdk
         };
 
     })();
@@ -293,3 +307,4 @@
     module.exports = FB;
 
 })();
+

--- a/fb.js
+++ b/fb.js
@@ -261,8 +261,10 @@
             }
             ,function(error, response, body) {
                 if(error !== null) {
-                    console.log(error);
-                    return;
+                    if(error.hasOwnProperty('error')) {
+                        return cb(error);
+                    }
+                    return cb({error:error});
                 }
 
                 if(cb) cb(JSON.parse(body));


### PR DESCRIPTION
I stripped out the timeout additions, and just left the error passing and removed the console.log.

I'll work on the options changes later tonight.
