### PR TITLE
Adding options method which includes the ability to set a timeout period

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Some examples of various error codes you can check for:
 
 ```js
 var FB = require('FB');
+FB.options({timeout: 1});
 FB.api('/me', function (res) {
     if(res && res.error) {
         if(res.error.code === 'ETIMEDOUT') {

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Some examples of various error codes you can check for:
 
 ```js
 var FB = require('FB');
-FB.setAccessToken('access_token');
+FB.options({timeout: 1, accessToken: 'access_token'});
 FB.api('/me', function (res) {
     if(res && res.error) {
         if(res.error.code === 'ETIMEDOUT') {

--- a/README.md
+++ b/README.md
@@ -398,16 +398,16 @@ Some examples of various error codes you can check for:
 var FB = require('FB');
 FB.options({timeout: 1});
 FB.api('/me', function (res) {
-    if(r && r.error)
-        if(r.error.code === 'ETIMEDOUT') {
+    if(res && res.error)
+        if(res.error.code === 'ETIMEDOUT') {
             console.log('request timeout');
         }
         else {
-            console.log('error', r.error);
+            console.log('error', res.error);
         }
     }
     else {
-        console.log(r);
+        console.log(res);
     }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -354,9 +354,11 @@ var accessToken = FB.getAccessToken();
 ```
 
 ## Configuration options
+
 *This is a non-standard api and does not exist in the official client side FB JS SDK.*
 
 ### options
+
 When this method is called with no parameters it will return all of the current options.
 
 ```js
@@ -379,8 +381,8 @@ var accessToken = FB.options('accessToken'); //will get the accessToken of 'XYZ'
 ```
 
 The existing options are:
-* `'accessToken'` this is identical to the `setAccessToken` and `getAccessToken` methods
-* `'timeout'` will requests that have not received a response in X ms. If set to null or 0 no timeout will exist. On timeout an error object will be returned to the api callback with the error code of `'ETIMEDOUT'` (example below)
+* `'accessToken'` string representing the facebook accessToken to be used for requests. This is the same option that is updated by the `setAccessToken` and `getAccessToken` methods.
+* `'timeout'` integer number of milliseconds to wait for a response. Requests that have not received a response in *X* ms. If set to null or 0 no timeout will exist. On timeout an error object will be returned to the api callback with the error code of `'ETIMEDOUT'` (example below).
 
 ## Error handling
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Some examples of various error codes you can check for:
 
 ```js
 var FB = require('FB');
-FB.options({timeout: 1});
+FB.setAccessToken('access_token');
 FB.api('/me', function (res) {
     if(res && res.error) {
         if(res.error.code === 'ETIMEDOUT') {

--- a/README.md
+++ b/README.md
@@ -353,6 +353,35 @@ FB.setAccessToken('access_token');
 var accessToken = FB.getAccessToken();
 ```
 
+## Configuration options
+*This is a non-standard api and does not exist in the official client side FB JS SDK.*
+
+### options
+When this method is called with no parameters it will return all of the current options.
+
+```js
+var FB = require('FB');
+var options = FB.options();
+```
+
+When this method is called with a string it will return the value of the option if exists, null if it does not.
+
+```js
+var timeout = FB.options('timeout');
+```
+
+When this method is called with an object it will merge the object onto the previous options object.
+```js
+FB.options({accessToken: 'abc'}); //equivalent to calling setAccessToken('abc')
+FB.options({timeout: 1000, accessToken: 'XYZ'}); //will set timeout and accessToken options
+var timeout = FB.options('timeout'); //will get a timeout of 1000
+var accessToken = FB.options('accessToken'); //will get the accessToken of 'XYZ'
+```
+
+The existing options are:
+* `'accessToken'` this is identical to the `setAccessToken` and `getAccessToken` methods
+* `'timeout'` will requests that have not received a response in X ms. If set to null or 0 no timeout will exist. On timeout an error object will be returned to the api callback with the error code of `'ETIMEDOUT'` (example below)
+
 ## Error handling
 
 *Note facebook is not consistent with their error format, and different systems can fail causing different error formats*
@@ -365,12 +394,18 @@ Some examples of various error codes you can check for:
 
 ```js
 var FB = require('FB');
+FB.options({timeout: 1});
 FB.api('/me', function (res) {
-    if(r && r.error && r.error.code === 'ETIMEDOUT') {
-        console.log('request timeout');
+    if(r && r.error)
+        if(r.error.code === 'ETIMEDOUT') {
+            console.log('request timeout');
+        }
+        else {
+            console.log('error', r.error);
+        }
     }
     else {
-        console.log(r.error);
+        console.log(r);
     }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -396,9 +396,8 @@ Some examples of various error codes you can check for:
 
 ```js
 var FB = require('FB');
-FB.options({timeout: 1});
 FB.api('/me', function (res) {
-    if(res && res.error)
+    if(res && res.error) {
         if(res.error.code === 'ETIMEDOUT') {
             console.log('request timeout');
         }

--- a/README.md
+++ b/README.md
@@ -352,3 +352,25 @@ var FB = require('FB');
 FB.setAccessToken('access_token');
 var accessToken = FB.getAccessToken();
 ```
+
+## Error handling
+
+*Note facebook is not consistent with their error format, and different systems can fail causing different error formats*
+
+Some examples of various error codes you can check for:
+* `'ECONNRESET'` - connection reset by peer
+* `'ETIMEDOUT'` - connection timed out
+* `'ESOCKETTIMEDOUT'` - socket timed out
+
+
+```js
+var FB = require('FB');
+FB.api('/me', function (res) {
+    if(r && r.error && r.error.code === 'ETIMEDOUT') {
+        console.log('request timeout');
+    }
+    else {
+        console.log(r.error);
+    }
+});
+```

--- a/fb.js
+++ b/fb.js
@@ -261,7 +261,7 @@
             }
             ,function(error, response, body) {
                 if(error !== null) {
-                    if(error.hasOwnProperty('error')) {
+                    if(error === Object(error) && error.hasOwnProperty('error')) {
                         return cb(error);
                     }
                     return cb({error:error});

--- a/fb.js
+++ b/fb.js
@@ -7,11 +7,18 @@
             , graph
             , rest
             , oauthRequest
-            , accessToken
             , setAccessToken
             , getAccessToken
             , log
+            , has
+            , options
             , METHODS = ['get', 'post', 'delete', 'put']
+            , opts = {
+                  'accessToken': null
+                , 'appId': null
+                , 'appSecret': null
+                , 'timeout': null
+            }
             , readOnlyCalls = {
                   'admin.getallocation': true
                 , 'admin.getappproperties': true
@@ -206,10 +213,11 @@
             var   uri
                 , body
                 , key
-                , value;
+                , value
+                , requestOptions;
 
-            if(!params.access_token && accessToken) {
-                params.access_token = accessToken;
+            if(!params.access_token && options('accessToken')) {
+                params.access_token = options('accessToken');
             }
 
             if(domain === 'graph') {
@@ -254,14 +262,18 @@
                 uri = uri.substring(0, uri.length -1);
             };
 
-            request({
+            requestOptions = {
                   method: method
                 , uri: uri
                 , body: body
+            };
+            if(options('timeout')) {
+                requestOptions['timeout'] = options('timeout');
             }
+            request(requestOptions
             ,function(error, response, body) {
                 if(error !== null) {
-                    if(error === Object(error) && error.hasOwnProperty('error')) {
+                    if(error === Object(error) && has(error, 'error')) {
                         return cb(error);
                     }
                     return cb({error:error});
@@ -276,18 +288,38 @@
             console.log(d);
         };
 
-        getAccessToken = function () {
-            return accessToken || null;  
+        has = function (obj, key) {
+            return Object.prototype.hasOwnProperty.call(obj, key);
         };
 
-        setAccessToken = function (access_token) {
-            accessToken = access_token;
+        getAccessToken = function () {
+            return options('accessToken');
+        };
+
+        setAccessToken = function (accessToken) {
+            options({'accessToken': accessToken});
+        };
+
+        options = function (o) {
+            var k;
+            if(!o) {
+                return opts;
+            }
+            if(Object.prototype.toString.call(o) == '[object String]') {
+                return has(opts, o) ? opts[o] : null;
+            }
+            for(k in opts) {
+                if(has(opts, k) && has(o, k)) {
+                    opts[k] = o[k];
+                }
+            }
         };
         
         return {
               api: api
             , getAccessToken: getAccessToken
             , setAccessToken: setAccessToken // this method does not exist in fb js sdk
+            , options: options // this method does not exist in the fb js sdk
         };
 
     })();

--- a/fb.js
+++ b/fb.js
@@ -261,8 +261,10 @@
             }
             ,function(error, response, body) {
                 if(error !== null) {
-                    console.log(error);
-                    return;
+                    if(error.hasOwnProperty('error')) {
+                        return cb(error);
+                    }
+                    return cb({error:error});
                 }
 
                 if(cb) cb(JSON.parse(body));

--- a/fb.js
+++ b/fb.js
@@ -216,6 +216,7 @@
                 , value
                 , requestOptions;
 
+            cb = cb || function() {};
             if(!params.access_token && options('accessToken')) {
                 params.access_token = options('accessToken');
             }


### PR DESCRIPTION
This pull request is updated with the merge of the other error pull request, if you want to handle that one first.

I added the options method the way you described, and added the ability to pass a string to get back a specific property

``` js
//sets just the timeout option to 2 seconds
FB.options({timeout: 2000});
//sets just the accessToken option to 'XYZ'
FB.options({accessToken: 'XYZ'});

//returns the options object
var options = FB.options(); 
//returns just the timeout property of the options object
var timeout = FB.options('timeout');

//unset both the timeout and accessToken options
FB.options({timeout: 0, accessToken: null});
```

I also went through and updated the rest of the code to use the options method as the main getter/setter for the accessToken.

The options method will only set properties for keys that are defined in the opts variable. So users won't be able to set garbage keys. I also left a spot for appId and appSecret, but it doesn't currently do anything.

I also updated the docs explain some of the `option()` stuff. Let me know if there are any remaining issues.
