### PR TITLE
FB.api can now handle oauth text/plain responses (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,65 @@ FB.api('', 'post', {
 });
 ```
 
+## OAuth Requests
+
+*This is a non-standard behavior and does not work in the official client side FB JS SDK.*
+
+facebook-node-sdk is capable of handling oauth requests which return non-json responses. You can use it by calling `api` method.
+
+### Get facebook application access token
+
+```javascript
+var FB = require('fb');
+
+FB.api('oauth/access_token', {
+    client_id: 'app_id',
+    client_secret: 'app_secret',
+    grant_type: 'client_credentials'
+}, function (res) {
+    if(res && !res.error) {
+        var accessToken = res.access_token;
+        console.log(accessToken);
+    }
+});
+```
+
+### Exchange code for access token
+
+```javascript
+var FB = require('./fb');
+
+FB.api('oauth/access_token', {
+    client_id: 'app_id',
+    client_secret: 'app_secret',
+    redirect_uri: 'http://yoururl.com/callback',
+    code: 'code'
+}, function (res) {
+    if(res && !res.error) {
+        var accessToken = res.access_token;
+        var expires = res.expires ? res.expires : 0;
+    }
+});
+```
+
+### Extend expiry time of the access token
+
+```javascript
+var FB = require('./fb');
+
+FB.api('oauth/access_token', {
+    client_id: 'client_id',
+    client_secret: 'client_secret',
+    grant_type: 'fb_exchange_token',
+    fb_exchange_token: 'existing_access_token'
+}, function (res) {
+    if(res && !res.error) {
+        var accessToken = res.access_token;
+        var expires = res.expires ? res.expires : 0;
+    }
+});
+```
+
 ## Legacy REST Api
 
 __Although Legacy REST Api is supported by facebook-node-sdk, it is highly discouraged to be used, as Facebook is in the process of deprecating the Legacy REST Api.__
@@ -323,65 +382,6 @@ FB.api({ method: 'stream.remove', post_id: postId }, function (res) {
    else {
        console.log(res);
    }
-});
-```
-
-### OAuth Requests
-
-*This is a non-standard behavior and does not work in the official client side FB JS SDK.*
-
-facebook-node-sdk is capable of handling oauth requests which return non-json responses. You can use it by calling `api` method.
-
-#### Get facebook application access token
-
-```javascript
-var FB = require('fb');
-
-FB.api('oauth/access_token', {
-    client_id: 'app_id',
-    client_secret: 'app_secret',
-    grant_type: 'client_credentials'
-}, function (res) {
-    if(res && !res.error) {
-        var accessToken = res.access_token;
-        console.log(accessToken);
-    }
-});
-```
-
-#### Exchange code for access token
-
-```javascript
-var FB = require('./fb');
-
-FB.api('oauth/access_token', {
-    client_id: 'app_id',
-    client_secret: 'app_secret',
-    redirect_uri: 'http://yoururl.com/callback',
-    code: 'code'
-}, function (res) {
-    if(res && !res.error) {
-        var accessToken = res.access_token;
-        var expires = res.expires ? res.expires : 0;
-    }
-});
-```
-
-#### Extend expiry time of the access token
-
-```javascript
-var FB = require('./fb');
-
-FB.api('oauth/access_token', {
-    client_id: 'client_id',
-    client_secret: 'client_secret',
-    grant_type: 'fb_exchange_token',
-    fb_exchange_token: 'existing_access_token'
-}, function (res) {
-    if(res && !res.error) {
-        var accessToken = res.access_token;
-        var expires = res.expires ? res.expires : 0;
-    }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -289,9 +289,12 @@ FB.api('oauth/access_token', {
     client_secret: 'app_secret',
     grant_type: 'client_credentials'
 }, function (res) {
-    if(res && !res.error) {
-        var accessToken = res.access_token;
+    if(!res || res.error) {
+        console.log(res.error);
+        return;
     }
+    
+    var accessToken = res.access_token;
 });
 ```
 
@@ -306,10 +309,13 @@ FB.api('oauth/access_token', {
     redirect_uri: 'http://yoururl.com/callback',
     code: 'code'
 }, function (res) {
-    if(res && !res.error) {
-        var accessToken = res.access_token;
-        var expires = res.expires ? res.expires : 0;
+    if(!res || res.error) {
+        console.log(res.error);
+        return;
     }
+
+    var accessToken = res.access_token;
+    var expires = res.expires ? res.expires : 0;
 });
 ```
 
@@ -324,10 +330,13 @@ FB.api('oauth/access_token', {
     grant_type: 'fb_exchange_token',
     fb_exchange_token: 'existing_access_token'
 }, function (res) {
-    if(res && !res.error) {
-        var accessToken = res.access_token;
-        var expires = res.expires ? res.expires : 0;
+    if(!res || res.error) {
+        console.log(res.error);
+        return;
     }
+    
+    var accessToken = res.access_token;
+    var expires = res.expires ? res.expires : 0;
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,24 @@ FB.api('oauth/access_token', {
 });
 ```
 
+#### Extend expiry time of the access token
+
+```javascript
+var FB = require('./fb');
+
+FB.api('oauth/access_token', {
+    client_id: 'client_id',
+    client_secret: 'client_secret',
+    grant_type: 'fb_exchange_token',
+    fb_exchange_token: 'existing_access_token'
+}, function (res) {
+    if(res && !res.error) {
+        var accessToken = res.access_token;
+        var expires = res.expires ? res.expires : 0;
+    }
+});
+```
+
 ## Access Tokens
 
 ### setAccessToken

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ With facebook-node-sdk you can now easily write the same code and share between 
 
 ```
 npm install fb
+```
 
+```javascript
 var FB = require('fb');
 ```
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,24 @@ FB.api('oauth/access_token', {
 });
 ```
 
+#### Exchange code for access token
+
+```javascript
+var FB = require('./fb');
+
+FB.api('oauth/access_token', {
+    client_id: 'app_id',
+    client_secret: 'app_secret',
+    redirect_uri: 'http://yoururl.com/callback',
+    code: 'code'
+}, function (res) {
+    if(res && !res.error) {
+        var accessToken = res.access_token;
+        var expires = res.expires ? res.expires : 0;
+    }
+});
+```
+
 ## Access Tokens
 
 ### setAccessToken

--- a/README.md
+++ b/README.md
@@ -326,6 +326,29 @@ FB.api({ method: 'stream.remove', post_id: postId }, function (res) {
 });
 ```
 
+### OAuth Requests
+
+*This is a non-standard behavior and does not work in the official client side FB JS SDK.*
+
+facebook-node-sdk is capable of handling oauth requests which return non-json responses. You can use it by calling `api` method.
+
+#### Get facebook application access token
+
+```javascript
+var FB = require('fb');
+
+FB.api('oauth/access_token', {
+    client_id: 'app_id',
+    client_secret: 'app_secret',
+    grant_type: 'client_credentials'
+}, function (res) {
+    if(res && !res.error) {
+        var accessToken = res.access_token;
+        console.log(accessToken);
+    }
+});
+```
+
 ## Access Tokens
 
 ### setAccessToken

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var FB = require('fb');
 
 FB.api('4', function (res) {
   if(!res || res.error) {
-   console.log(res.error);
+   console.log(!res ? 'error occurred' : res.error);
    return;
   }
   console.log(res.id);
@@ -36,7 +36,7 @@ var FB = require('fb');
 
 FB.api('4', { fields: ['id', 'name'] }, function (res) {
   if(!res || res.error) {
-    console.log(res.error);
+    console.log(!res ? 'error occurred' : res.error);
     return;
   }
   console.log(res.id);
@@ -53,7 +53,7 @@ FB.setAccessToken('access_token');
 var body = 'My first post using facebook-node-sdk';
 FB.api('me/feed', 'post', { message: body}, function (res) {
   if(!res || res.error) {
-    console.log(res.error);
+    console.log(!res ? 'error occurred' : res.error);
     return;
   }
   console.log('Post Id: ' + res.id);
@@ -69,7 +69,7 @@ FB.setAccessToken('access_token');
 var postId = '1234567890';
 FB.api(postId, 'delete', function (res) {
   if(!res || res.error) {
-    console.log(res.error);
+    console.log(!res ? 'error occurred' : res.error);
     return;
   }
   console.log('Post was deleted');
@@ -86,7 +86,7 @@ FB.setAccessToken('access_token');
 
 FB.api('fql', { q: 'SELECT uid FROM user WHERE uid=me()' }, function (res) {
   if(!res || res.error) {
-    console.log(res.error);
+    console.log(!res ? 'error occurred' : res.error);
     return;
   }
   console.log(res.data);
@@ -104,7 +104,7 @@ FB.api('fql', { q: [
   'SELECT name FROM user WHERE uid=me()'
 ] }, function(res) {
   if(!res || res.error) {
-    console.log(res.error);
+    console.log(!res ? 'error occurred' : res.error);
     return;
   }
   console.log(res.data[0].fql_result_set);
@@ -123,7 +123,7 @@ FB.api('fql', { q : {
   name: 'SELECT name FROM user WHERE uid IN (SELECT uid FROM #id)'
 } }, function(res) {
   if(!res || res.error) {
-    console.log(res.error);
+    console.log(!res ? 'error occurred' : res.error);
     return;
   }
   console.log(res.data[0].fql_result_set);
@@ -160,7 +160,7 @@ FB.api('', 'post', {
         etag1;
 
     if(!res || res.error) {
-        console.log(res.error);
+        console.log(!res ? 'error occurred' : res.error);
         return;
     }
 
@@ -261,7 +261,7 @@ FB.api('', 'post', {
     var res0;
 
     if(!res || res.error) {
-        console.log(res.error);
+        console.log(!res ? 'error occurred' : res.error);
         return;
     }
 
@@ -292,7 +292,7 @@ FB.api('oauth/access_token', {
     grant_type: 'client_credentials'
 }, function (res) {
     if(!res || res.error) {
-        console.log(res.error);
+        console.log(!res ? 'error occurred' : res.error);
         return;
     }
     
@@ -312,7 +312,7 @@ FB.api('oauth/access_token', {
     code: 'code'
 }, function (res) {
     if(!res || res.error) {
-        console.log(res.error);
+        console.log(!res ? 'error occurred' : res.error);
         return;
     }
 
@@ -333,7 +333,7 @@ FB.api('oauth/access_token', {
     fb_exchange_token: 'existing_access_token'
 }, function (res) {
     if(!res || res.error) {
-        console.log(res.error);
+        console.log(!res ? 'error occurred' : res.error);
         return;
     }
     
@@ -353,12 +353,12 @@ var FB = require('fb');
 
 FB.api({ method: 'users.getInfo', uids: ['4'], fields: ['uid', 'name'] }, function (res) {
     if(!res || res.error_msg) {
-        console.log(res.error_msg);
+        console.log(!res ? 'error occurred' : res.error_msg);
+        return;
     }
-    else {
-        console.log('User Id: ' + res[0].uid);
-        console.log('Name: ' + res[0].name);
-    }
+
+    console.log('User Id: ' + res[0].uid);
+    console.log('Name: ' + res[0].name);
 });
 ```
 
@@ -371,11 +371,11 @@ FB.setAccessToken('access_token');
 var message = 'Hi from facebook-node-sdk';
 FB.api({ method: 'stream.publish', message: message }, function (res) {
     if(!res || res.error_msg) {
-        console.log(res.error_msg);
+        console.log(!res ? 'error occurred' : res.error_msg);
+        return;
     }
-    else {
-        console.log(res);
-    }
+    
+    console.log(res);
 });
 ```
 ### Delete

--- a/README.md
+++ b/README.md
@@ -291,7 +291,6 @@ FB.api('oauth/access_token', {
 }, function (res) {
     if(res && !res.error) {
         var accessToken = res.access_token;
-        console.log(accessToken);
     }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -321,6 +321,30 @@ FB.api('oauth/access_token', {
 });
 ```
 
+You can safely extract the code from the url using the `url` module. Always make sure to handle invalid oauth callback as
+well as error.
+
+```javascript
+var url = require('url');
+var FB = require('./fb');
+
+var urlToParse = 'http://yoururl.com/callback?code=.....#_=_';
+var result = url.parse(urlToParse, true);
+if(result.query.error) {
+    if(result.query.error_description) {
+        console.log(result.query.error_description);
+    } else {
+        console.log(result.query.error);
+    }
+    return;
+} else if (!result.query.code) {
+    console.log('not a oauth callback');
+    return;
+}
+
+var code = result.query.code;
+```
+
 ### Extend expiry time of the access token
 
 ```javascript
@@ -386,12 +410,12 @@ FB.setAccessToken('access_token');
 
 var postId = '.....';
 FB.api({ method: 'stream.remove', post_id: postId }, function (res) {
-   if(!res || res.error_msg) {
-       console.log(res.error_msg);
-   }
-   else {
-       console.log(res);
-   }
+    if(!res || res.error_msg) {
+        console.log(!res ? 'error occurred' : res.error_msg);
+        return;
+    }
+    
+    console.log(res);
 });
 ```
 

--- a/fb.js
+++ b/fb.js
@@ -222,6 +222,7 @@
                 , isOAuthRequest
                 , oauthResult
                 , oauthKey
+                , oauthValue
                 , oauthSplit;
 
             cb = cb || function() {};
@@ -296,7 +297,12 @@
                     for(oauthKey in body) {
                         oauthSplit = body[oauthKey].split('=');
                         if(oauthSplit.length === 2) {
-                            oauthResult[oauthSplit[0]] = oauthSplit[1];
+                            oauthValue = oauthSplit[1];
+                            if(!isNaN(oauthValue)) {
+                                oauthResult[oauthSplit[0]] = parseInt(oauthValue);
+                            } else {
+                                oauthResult[oauthSplit[0]] = oauthValue;
+                            }
                         }
                     }
                     if(cb) cb(oauthResult);


### PR DESCRIPTION
pull request for #11

FB.api is now aware of text/plain oauth responses. so the following code or any oauth 2 request will now work.

``` js
FB.api('oauth/access_token', {client_id: '...', client_secret: '...', grant_type: 'client_credentials' }, function (res) {
    console.log(res);
})
```

I still think this might not be a good idea as we have to do regex test every time for a graph api call that results in 200ok status.

@jimzim @jschluchter should we make `FB.api` work with oauth response or create a new method and use `FB.oauth` instead. What do you guys think?

By the way fb c# sdk in v6 uses this same approach so `FacebookClient.Get("oauth/access_token")` works. One good thing about this method is no new api is introduced and devs can leverage existing knowledge.
