### PR TITLE
Add a try/catch around JSON.parse 

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ Some examples of various error codes you can check for:
 * `'ECONNRESET'` - connection reset by peer
 * `'ETIMEDOUT'` - connection timed out
 * `'ESOCKETTIMEDOUT'` - socket timed out
-
+* `'JSONPARSE'` - could not parse JSON response, happens when the FB API has availability issues. It sometimes returns HTML
 
 ```js
 var FB = require('FB');

--- a/fb.js
+++ b/fb.js
@@ -293,7 +293,12 @@
                     response.headers && /.*text\/plain.*/.test(response.headers['content-type'])) {
                     cb(parseOAuthApiResponse(body));
                 } else {
-                    cb(JSON.parse(body));
+                    try {
+                        // sometimes FB is dumb and returns HTML responses... so we try/catch here
+                        cb(JSON.parse(body));
+                    } catch (ex) {
+                        cb({ error: "JSON Error:" + ex.message });
+                    }
                 }
             });
         };

--- a/fb.js
+++ b/fb.js
@@ -299,7 +299,10 @@
                         // let's not let them blow up our application.
                         cb(JSON.parse(body));
                     } catch (ex) {
-                        cb({ error: "JSON Error:" + ex.message });
+                        cb({ error: {
+                            code: 'JSONPARSE',
+                            Error: new Error("JSON Error:" + ex.message)
+                        }});
                     }
                 }
             });

--- a/fb.js
+++ b/fb.js
@@ -301,8 +301,8 @@
                     } catch (ex) {
                         cb({ error: {
                             code: 'JSONPARSE',
-                            Error: new Error("JSON Error:" + ex.message)
-                        }});
+                            Error: ex
+                        }})
                     }
                 }
             });

--- a/fb.js
+++ b/fb.js
@@ -294,7 +294,9 @@
                     cb(parseOAuthApiResponse(body));
                 } else {
                     try {
-                        // sometimes FB is dumb and returns HTML responses... so we try/catch here
+                        // sometimes FB is has API errors that return HTML and a message 
+                        // of "Sorry, something went wrong". These are infrequent and unpredictable but
+                        // let's not let them blow up our application.
                         cb(JSON.parse(body));
                     } catch (ex) {
                         cb({ error: "JSON Error:" + ex.message });


### PR DESCRIPTION
Was reading this https://github.com/Thuzi/facebook-node-sdk/pull/27

Here's your pull request with a try/catch around JSON.parse and hopefully handling it a little better than letting the exception bubble all the way up.
