### PR TITLE
changed FB.options('redirect_uri') to FB.options('redirectUri')

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ The existing options are:
 * `'appSecret'` string representing the facebook application secret.
 * `'timeout'` integer number of milliseconds to wait for a response. Requests that have not received a response in *X* ms. If set to null or 0 no timeout will exist. On timeout an error object will be returned to the api callback with the error code of `'ETIMEDOUT'` (example below).
 
-`'scope'` and `'redirect_uri'` have been whitelisted in options for convenience. These value will not be automatically
+`'scope'` and `'redirectUri'` have been whitelisted in options for convenience. These value will not be automatically
 added when using any of the sdk apis unlike the above options. These are whitelisted so you can use it to pass values
 using the same `FB` object.
 

--- a/fb.js
+++ b/fb.js
@@ -26,7 +26,7 @@
                 , 'appSecret': null
                 , 'timeout': null
                 , 'scope':  null
-                , 'redirect_uri': null
+                , 'redirectUri': null
             }
             , readOnlyCalls = {
                   'admin.getallocation': true

--- a/samples/scrumptious/routes/home.js
+++ b/samples/scrumptious/routes/home.js
@@ -7,13 +7,13 @@ FB.options({
     appId:          config.facebook.appId,
     appSecret:      config.facebook.appSecret,
     scope:          config.facebook.scope,
-    redirect_uri:   config.facebook.redirectUri
+    redirectUri:    config.facebook.redirectUri
 });
 
 function getFacebookLoginUrl () {
     return 'https://www.facebook.com/dialog/oauth' +
         '?client_id='    + FB.options('appId') +
-        '&redirect_uri=' + encodeURIComponent(FB.options('redirect_uri')) +
+        '&redirect_uri=' + encodeURIComponent(FB.options('redirectUri')) +
         '&scope='        + encodeURIComponent(FB.options('scope'));
 }
 
@@ -45,7 +45,7 @@ exports.loginCallback = function (req, res, next) {
     FB.api('oauth/access_token', {
         client_id:      FB.options('appId'),
         client_secret:  FB.options('appSecret'),
-        redirect_uri:   FB.options('redirect_uri'),
+        redirect_uri:   FB.options('redirectUri'),
         code:           code
     }, function (result) {
         if(!result || result.error) {


### PR DESCRIPTION
changed `FB.options('redirect_uri')` to `FB.options('redirectUri')` so it is consistent with `appId`, `appSecret` and `accessToken`.

**breaking change**

PR for #34
