### PR TITLE
Fixed bug leading to invalid accessTokens when using Questionmarks in ap...

### DIFF
--- a/fb.js
+++ b/fb.js
@@ -247,7 +247,7 @@
             if(method === 'post') {
                 body = '';
                 if(params.access_token) {
-				    if((uri.indexOf("?") != -1)){
+                    if((uri.indexOf("?") !== -1)) {
                         uri += '&';
                     }
                     else {
@@ -271,7 +271,7 @@
                     body = body.substring(0, body.length - 1);
                 }
             } else {
-                if((uri.indexOf("?") != -1)){
+                if((uri.indexOf("?") !== -1)) {
                     uri += '&';
                 }
                 else {

--- a/fb.js
+++ b/fb.js
@@ -247,7 +247,13 @@
             if(method === 'post') {
                 body = '';
                 if(params.access_token) {
-                    uri += '?access_token=' + encodeURIComponent(params.access_token);
+				    if((uri.indexOf("?") != -1)){
+                        uri += '&';
+                    }
+                    else {
+                        uri += '?';
+                    }
+                    uri += 'access_token=' + encodeURIComponent(params.access_token);
                     delete params['access_token'];
                 }
 
@@ -265,7 +271,12 @@
                     body = body.substring(0, body.length - 1);
                 }
             } else {
-                uri += '?';
+                if((uri.indexOf("?") != -1)){
+                    uri += '&';
+                }
+                else {
+                    uri += '?';
+                }
                 for(key in params) {
                     value = params[key];
                     if(typeof value !== 'string') {


### PR DESCRIPTION
When you use a '?' in your api-calls the accesstoken gets appended with another '?' https://github.com/Thuzi/facebook-node-sdk/blob/master/fb.js#L268

This leads to a api-call like this one: https://graph.facebook.com/me/friends?limit=10?access_token=vSAEFfionhaWFwai...

You see multible '?' in the request and Facebook can not find the accesstoken anymore because of this
