### PR TITLE
Fixed the way custom errors are created

### DIFF
--- a/fb.js
+++ b/fb.js
@@ -462,7 +462,8 @@
             this.response = res;
         }
 
-        FacebookApiException.prototype = Error.prototype;
+        FacebookApiException.prototype = Object.create(Error.prototype);
+        FacebookApiException.prototype.constructor = FacebookApiException;
 
         nodeifyCallback = function (originalCallback) {
             // normalizes the callback parameters so that the


### PR DESCRIPTION
As some people pointed out to me on StackOverflow, the correct way to create custom errors is by passing an instance of Error as prototype, not Error's prototype itself. I thought I'd share with you.
See comments here : http://stackoverflow.com/questions/23377382/how-do-i-determine-if-a-variable-is-an-error-in-javascript#23377596
