### PR TITLE
Handle non-JSON responses from the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,12 @@ __Expecting a non-JSON response__
 ```js
 var FB = require('fb');
 
-// by default, the library expects a JSON response and will return an error otherwise.
-// a contentType option can be provided in the fourth parameter to prevent this.
-// for example, set contentType to 'image/jpeg', ['image/jpeg', 'image/gif'] or just 'any'
+/* By default, the library expects a JSON response and will try to parse
+*  it before it is returned to you. An error is returned if this cannot be performed.
+*  A contentType option (which defaults to 'application/json') can be provided
+*  through the fourth parameter to prevent this. For example, set contentType
+*  to 'image/jpeg', ['image/jpeg', 'image/gif'] or just 'any'.
+*/
 FB.api('4/picture', { redirect: 1 }, { contentType: 'any' }, function (res) {
   if(!res || res.error) {
     console.log(!res ? 'error occurred' : res.error);

--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ FB.api('4', { fields: ['id', 'name'] }, function (res) {
 });
 ```
 
+__Expecting a non-JSON response__
+
+```js
+var FB = require('fb');
+
+// by default, the library expects a JSON response and will return an error otherwise.
+// a contentType option can be provided in the fourth parameter to prevent this.
+// for example, set content type to 'image/jpeg', ['image/jpeg', 'image/gif'] or just 'any'
+FB.api('4/picture', { redirect: 1 }, { contentType: 'any'}, function (res) {
+  if(!res || res.error) {
+    console.log(!res ? 'error occurred' : res.error);
+    return;
+  }
+  console.log(res.id);
+  console.log(res.name);
+});
+```
+
 ### Post
 
 ```js

--- a/README.md
+++ b/README.md
@@ -67,14 +67,13 @@ var FB = require('fb');
 
 // by default, the library expects a JSON response and will return an error otherwise.
 // a contentType option can be provided in the fourth parameter to prevent this.
-// for example, set content type to 'image/jpeg', ['image/jpeg', 'image/gif'] or just 'any'
-FB.api('4/picture', { redirect: 1 }, { contentType: 'any'}, function (res) {
+// for example, set contentType to 'image/jpeg', ['image/jpeg', 'image/gif'] or just 'any'
+FB.api('4/picture', { redirect: 1 }, { contentType: 'any' }, function (res) {
   if(!res || res.error) {
     console.log(!res ? 'error occurred' : res.error);
     return;
   }
-  console.log(res.id);
-  console.log(res.name);
+  console.log('Picture fetched. "Res" can be written in a file on disk.');
 });
 ```
 

--- a/fb.js
+++ b/fb.js
@@ -189,7 +189,7 @@
             params = params || {};
             
             var defaultOptions = {
-                contentType: 'json'
+                contentType: 'application/json'
             };
             reqOptions = reqOptions || {};
             for(key in defaultOptions){
@@ -321,7 +321,7 @@
                 } else {
                     var ret;
                     // special treatment for (expected) json responses : decode them
-                    if(reqOptions.contentType == 'json'){
+                    if(reqOptions.contentType == 'application/json'){
                         try {
                             ret = JSON.parse(body);
                         } catch (ex) {

--- a/fb.js
+++ b/fb.js
@@ -142,8 +142,8 @@
          * Make a api call to Graph server.
          *
          * Except the path, all arguments to this function are optional.
-		 * Only if reqOptions is defined, then params must be provided (an object or null)
-		 * So any of these are valid:
+         * Only if reqOptions is defined, then params must be provided (an object or null)
+         * So any of these are valid:
          *
          *  FB.api('/me') // throw away the response
          *  FB.api('/me', function(r) { console.log(r) })
@@ -187,16 +187,16 @@
 
             method = method || 'get';
             params = params || {};
-			
-			var defaultOptions = {
-				contentType: 'json'
-			};
+            
+            var defaultOptions = {
+                contentType: 'json'
+            };
             reqOptions = reqOptions || {};
-			for(key in defaultOptions){
-				if(typeof reqOptions[key] == 'undefined'){
-					reqOptions[key] = defaultOptions[key];
-				}
-			}
+            for(key in defaultOptions){
+                if(typeof reqOptions[key] == 'undefined'){
+                    reqOptions[key] = defaultOptions[key];
+                }
+            }
 
             // remove prefix slash if one is given, as it's already in the base url
             if(path[0] === '/') {
@@ -319,41 +319,41 @@
                     response.headers && /.*text\/plain.*/.test(response.headers['content-type'])) {
                     cb(parseOAuthApiResponse(body));
                 } else {
-					var ret;
-					// special treatment for (expected) json responses : decode them
-					if(reqOptions.contentType == 'json'){
-						try {
-							ret = JSON.parse(body);
-						} catch (ex) {
-						  // sometimes FB is has API errors that return HTML and a message
-						  // of "Sorry, something went wrong". These are infrequent and unpredictable but
-						  // let's not let them blow up our application.
-						  ret =  { error: {
-							  code: 'JSONPARSE',
-							  Error: ex
-						  }};
-						}
-					}
-					else {
-						// check that the content is of expected type(s)
-						if(		reqOptions.contentType == 'any'
-							||	(	response.headers
-								&&	(
-										(typeof reqOptions.contentType == 'string' && reqOptions.contentType == response.headers['content-type'])
-									||	(Array.isArray(reqOptions.contentType) && reqOptions.contentType.indexOf(response.headers['content-type']) !== -1)
-								)
-							)
-						){
-							ret = body;
-						}
-						else {
-							ret =  { error: {
-								code: 'UNEXPECTED_CONTENT-TYPE',
-								expected: reqOptions.contentType,
-								received: response.headers['content-type']
-							}};
-						}
-					}
+                    var ret;
+                    // special treatment for (expected) json responses : decode them
+                    if(reqOptions.contentType == 'json'){
+                        try {
+                            ret = JSON.parse(body);
+                        } catch (ex) {
+                          // sometimes FB is has API errors that return HTML and a message
+                          // of "Sorry, something went wrong". These are infrequent and unpredictable but
+                          // let's not let them blow up our application.
+                          ret =  { error: {
+                              code: 'JSONPARSE',
+                              Error: ex
+                          }};
+                        }
+                    }
+                    else {
+                        // check that the content is of expected type(s)
+                        if(        reqOptions.contentType == 'any'
+                            ||    (    response.headers
+                                &&    (
+                                        (typeof reqOptions.contentType == 'string' && reqOptions.contentType == response.headers['content-type'])
+                                    ||    (Array.isArray(reqOptions.contentType) && reqOptions.contentType.indexOf(response.headers['content-type']) !== -1)
+                                )
+                            )
+                        ){
+                            ret = body;
+                        }
+                        else {
+                            ret =  { error: {
+                                code: 'UNEXPECTED_CONTENT-TYPE',
+                                expected: reqOptions.contentType,
+                                received: response.headers['content-type']
+                            }};
+                        }
+                    }
                     cb(ret);
                 }
             });
@@ -646,7 +646,7 @@
                 if(options('proxy')) {
                     requestOptions['proxy'] = options('proxy');
                 }
-			
+            
                 request(
                     requestOptions
                     , function(error, response, body) {


### PR DESCRIPTION
Facebook API endpoints such as `/me/picture` return things other the JSON. The library made the choice to believe any non-JSON response is an error, which is not the case.

I introduced an optional fourth 'reqOptions' parameter for the api/napi method. Currently, there is only one option in there : accepting responses of content-type other than json (see the updated Readme). You can provide a content-type string, an array of content-type strings, or just the string 'any'. I added the `encoding: 'binary'` option to the request module to allow pictures, videos and such.
