### PR TITLE
Automatically handle the appsecret_proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,11 @@ var FB = require('fb');
 FB.setAccessToken('access_token');
 var accessToken = FB.getAccessToken();
 ```
+
+### AppSecret Proof
+For improved security, as soon as you provide an app secret and an access token, the
+library automatically computes and adds the appsecret_proof parameter to your requests.
+
 ## Configuration options
 
 ### options

--- a/fb.js
+++ b/fb.js
@@ -16,6 +16,7 @@
             , parseOAuthApiResponse
             , setAccessToken
             , getAccessToken
+            , getAppSecretProof
             , parseSignedRequest
             , base64UrlDecode
             , log
@@ -26,6 +27,7 @@
                   'accessToken': null
                 , 'appId': null
                 , 'appSecret': null
+                , 'appSecretProof': null
                 , 'timeout': null
                 , 'scope':  null
                 , 'redirectUri': null
@@ -230,8 +232,16 @@
                 , isOAuthRequest;
 
             cb = cb || function() {};
-            if(!params.access_token && options('accessToken')) {
-                params.access_token = options('accessToken');
+            if(!params.access_token) {
+                if(opts.accessToken) {
+                    params.access_token = opts.accessToken;
+                    if(opts.appSecret) {
+                        params.appsecret_proof = opts.appSecretProof;
+                    }
+                }
+            }
+            else if(!params.appsecret_proof && opts.appSecret) {
+                params.appsecret_proof = getAppSecretProof(params.access_token, opts.appSecret);
             }
 
             if(domain === 'graph') {
@@ -250,6 +260,11 @@
                 if(params.access_token) {
                     uri += '?access_token=' + encodeURIComponent(params.access_token);
                     delete params['access_token'];
+                    
+                    if(params.appsecret_proof) {
+                        uri += '&appsecret_proof=' + encodeURIComponent(params.appsecret_proof);
+                        delete params['appsecret_proof'];
+                    }
                 }
 
                 for(key in params) {
@@ -357,6 +372,12 @@
         setAccessToken = function (accessToken) {
             options({'accessToken': accessToken});
         };
+        
+        getAppSecretProof = function (accessToken, appSecret) {
+            var hmac = crypto.createHmac('sha256', appSecret);
+            hmac.update(accessToken);
+            return hmac.digest('hex');
+        };
 
         /**
          *
@@ -448,9 +469,19 @@
             for(key in opts) {
                 if(has(opts, key) && has(keyOrOptions, key)) {
                     opts[key] = keyOrOptions[key];
-                    if(key == 'appId') {
-                        // ping Facebook for instrumentation requirement
-                        pingFacebook(opts[key]);
+                    switch(key){
+                        case 'appId':
+                            // ping Facebook for instrumentation requirement
+                            pingFacebook(opts[key]);
+                            break;
+                        
+                        case 'appSecret':
+                        case 'accessToken':
+                            opts.appSecretProof =
+                                (opts.appSecret && opts.accessToken) ?
+                                getAppSecretProof(opts[key], opts.appSecret) :
+                                null;
+                            break;
                     }
                 }
             }


### PR DESCRIPTION
This PR automates the generation and appending of the appsecret_proof parameter that improves security of the application. See https://developers.facebook.com/docs/graph-api/securing-requests/
