### PR TITLE
Case where appSecretProof was calculated incorrectly

### DIFF
--- a/fb.js
+++ b/fb.js
@@ -493,7 +493,7 @@
                         case 'accessToken':
                             opts.appSecretProof =
                                 (opts.appSecret && opts.accessToken) ?
-                                getAppSecretProof(opts[key], opts.appSecret) :
+                                getAppSecretProof(opts.accessToken, opts.appSecret) :
                                 null;
                             break;
                     }


### PR DESCRIPTION
When using FB.options to set both the appSecret and accessToken the appSecretProof was being calculated incorrectly. Essentially the appSecret gets passed as both parameters to the getAppSecretProof method.

This is how I am using the options.

``` javascript
FB.options( {appSecret: '', accessToken: ''} );
FB.api('me', 'get', function(res) {
  console.log(res);
});
```
